### PR TITLE
Update ipWhiteList to correct RFC-1918 networks

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -136,9 +136,9 @@ http:
     default-whitelist:
       ipWhiteList:
         sourceRange:
-        - "10.0.0.0/24"
+        - "10.0.0.0/8"
         - "192.168.0.0/16"
-        - "172.0.0.0/8"
+        - "172.16.0.0/12"
 
     secured:
       chain:


### PR DESCRIPTION
The 172.16.x.x network is only from 172.16.x.x - 172.31.x.x. I've updated this in the whitelist to ensure this only uses the RFC 1918 networks
The 10.x.x.x. network is a /8 as per the RFC-1918 standards. I've updated this as well
(i'm going on the assumption that we want this as private networks and not publicly routable networks)