### PR TITLE
Use host's data dir for container's data

### DIFF
--- a/reference_files/traefik-portainer-ssl/portainer/docker-compose.yml
+++ b/reference_files/traefik-portainer-ssl/portainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /home/username/portainer:/data
+      - /home/username/portainer/data:/data
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.portainer.entrypoints=http"


### PR DESCRIPTION
The earlier config didn't use the directory you created earlier for container's data.

--
Btw great job! Thank you.