### PR TITLE
Traefik SSL guide: Apache not needed for htpasswd

### DIFF
--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -109,11 +109,11 @@ mkdir data
 
 ```bash
 sudo apt update
-sudo apt install apache2 apache2-utils
+sudo apt install apache2-utils
 ```
 
 ```bash
-`echo $(htpasswd -nb USER PASSWORD) | sed -e s/\\$/\\$\\$/g`
+echo $(htpasswd -nb USER PASSWORD) | sed -e s/\\$/\\$\\$/g
 ```
 
 use this in your `docker-compose.yml` (`USER:BASIC_AUTH_PASSWORD`)


### PR DESCRIPTION
Installing apache in many cases make apache automatically start and bind to port 80. This causes traefik to not work later on since port 80 is already in use.
apache2-utils is enough to get access to htpasswd. 

Alternatively, installation of apache2-utils could be skipped altogether with `echo "USER:$(openssl passwd -apr1 PASSWORD)" | sed -e s/\\$/\\$\\$/g`, but I haven't tried it personally.
