### PR TITLE
Updating minor commands

### DIFF
--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -125,12 +125,12 @@ docker-compose up -d
 ## Traefik Routes Config
 
 ```bash
-cd traefik
+cd traefik/data
 nano config.yml
 ```
 
 `config.yml` [here](https://github.com/techno-tim/techno-tim.github.io/tree/master/reference_files/traefik-portainer-ssl/traefik) 
 
 ```bash
-docker-compose -d --force-recreate
+docker-compose up -d --force-recreate
 ```


### PR DESCRIPTION
Fixing docker-compose command. Fixing CD location for config.

--force-recreate for docker-compose needs the `up` flag. The correct directory of the `config.yml` file is in traefik/data in the desired directory. 