### PR TITLE
Fixes missing hyphen in proxmox 7 post

### DIFF
--- a/_posts/2021-07-10-proxmox-7.md
+++ b/_posts/2021-07-10-proxmox-7.md
@@ -18,7 +18,7 @@ As you may know, proxmox is my current choice for a hypervisor. Proxmox 7 is her
 Check your upgrade status
 
 ```bash
-pve6to7 –full
+pve6to7 --full
 ```
 
 First, make sure we have the latest packages


### PR DESCRIPTION
https://techno-tim.github.io/posts/proxmox-7/ is missing one hyphen when running the command `pve6to7 –full
` as seen under commands.

I don't know how this site is built but I believe changing the file should update it no?

If you run `pve6to7 –full` as is, it returns the following response:
```
400 too many arguments
checklist  [OPTIONS]
```

This changes it to --full as per the proxmox documentation.
