### PR TITLE
Update 2021-04-17-traefik-portainer-ssl.md

### DIFF
--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -77,7 +77,7 @@ echo $(htpasswd -nb <USER> <PASSWORD>) | sed -e s/\\$/\\$\\$/g
 ```
 NOTE: Replace `<USER>` with your username and `<PASSWORD>` with your password to be hashed.
 
-Paste the out put in your `docker-compose.yml` in line (`traefik.http.middlewares.traefik-auth.basicauth.users=<USER>:<HASHED-PASSWORD>`)
+Paste the output in your `docker-compose.yml` in line (`traefik.http.middlewares.traefik-auth.basicauth.users=<USER>:<HASHED-PASSWORD>`)
 
 #### Sping up the container
 ```bash

--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -75,9 +75,11 @@ sudo apt install apache2-utils
 ```bash
 echo $(htpasswd -nb USER PASSWORD) | sed -e s/\\$/\\$\\$/g
 ```
+NOTE: Replace USER with your username and PASSWORD with your password to be hashed.
 
-use this in your `docker-compose.yml` (`USER:BASIC_AUTH_PASSWORD`)
+Paste the out put in your `docker-compose.yml` (`traefik.http.middlewares.traefik-auth.basicauth.users=USER:HASHED-PASSWORD`)
 
+#### Sping up the container
 ```bash
 docker-compose up -d
 ```

--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -73,11 +73,11 @@ sudo apt install apache2-utils
 ```
 
 ```bash
-echo $(htpasswd -nb USER PASSWORD) | sed -e s/\\$/\\$\\$/g
+echo $(htpasswd -nb <USER> <PASSWORD>) | sed -e s/\\$/\\$\\$/g
 ```
-NOTE: Replace USER with your username and PASSWORD with your password to be hashed.
+NOTE: Replace `<USER>` with your username and `<PASSWORD>` with your password to be hashed.
 
-Paste the out put in your `docker-compose.yml` (`traefik.http.middlewares.traefik-auth.basicauth.users=USER:HASHED-PASSWORD`)
+Paste the out put in your `docker-compose.yml` in line (`traefik.http.middlewares.traefik-auth.basicauth.users=<USER>:<HASHED-PASSWORD>`)
 
 #### Sping up the container
 ```bash


### PR DESCRIPTION
Added a note about replacing USER with your username and PASSWORD with your password for the Basic Auth command and changed the wording for were to place it in the docker-compose file.