### PR TITLE
Dell iDRAC Traefik configuration

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -144,7 +144,7 @@ http:
     https-redirect:
       redirectScheme:
         scheme: https
-    
+
     default-headers:
       headers:
         frameDeny: true

--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -66,6 +66,22 @@ http:
         - default-headers
       tls: {}
       service: rancher
+    idrac:
+      entryPoints:
+        - "https"
+      rule: "Host(`idrac.local.example.com`)"
+      middlewares:
+      1  - idrac
+      tls: {}
+      service: idrac
+    idrac-console:
+      entryPoints:
+        - "idrac" # REQUIRED for iDRAC virtual console: Create a new TCP entry point in traefik on port 5900
+      rule: "Host(`idrac.local.example.com`)"
+      middlewares:
+        - idrac
+      tls: {}
+      service: idrac-console
 
 #endregion
 #region services
@@ -110,6 +126,16 @@ http:
         servers:
           - url: "https://192.168.0.107"
         passHostHeader: true
+    idrac:
+      loadBalancer:
+        servers:
+          - url: "https://192.168.0.108"
+        passHostHeader: true
+    idrac-console:
+      loadBalancer:
+        servers:
+          - url: "https://192.168.0.108:5900"
+        passHostHeader: true
 #endregion
   middlewares:
     addprefix-pihole:
@@ -118,7 +144,7 @@ http:
     https-redirect:
       redirectScheme:
         scheme: https
-
+    
     default-headers:
       headers:
         frameDeny: true
@@ -128,6 +154,18 @@ http:
         forceSTSHeader: true
         stsIncludeSubdomains: true
         stsPreload: true
+        stsSeconds: 15552000
+        customFrameOptionsValue: SAMEORIGIN
+        customRequestHeaders:
+          X-Forwarded-Proto: https
+
+    idrac:
+      headers:
+        frameDeny: true
+        sslRedirect: true
+        browserXssFilter: true
+        forceSTSHeader: true
+        stsIncludeSubdomains: true
         stsSeconds: 15552000
         customFrameOptionsValue: SAMEORIGIN
         customRequestHeaders:

--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -71,7 +71,7 @@ http:
         - "https"
       rule: "Host(`idrac.local.example.com`)"
       middlewares:
-      1  - idrac
+        - idrac
       tls: {}
       service: idrac
     idrac-console:


### PR DESCRIPTION
Additional generic configuration for including Dell's iDRAC interface and virtual console.  

Added routers, services and a middleware.

Routers - Two routers, one for the interface and one for the virtual console.  **NOTE: the following entry point is required in your Traefik configuration to allow the virtual console to connect:**

```
--entryPoints.idrac.address=:5900/tcp
```

Services - Two services, one on 443 and one on the above port 5900 for virtual console

Middleware - Notable deletions from `default-headers`:

- `contentTypeNosniff` - The `X-Content-Type-Options: true` header causes the `jsesp` scripts from dell to not be able to be executed because they are text/html on the server, but this requires that the MIME type be application/javascript.  Omit this to allow Dell's scripts to run
- `stsPreload` - The `Strict-Transport-Security` with the `preload` tag prevents login and even loading the virtual console.  Omit this for iDRAC.