### PR TITLE
Basic Auth Documentation and Tool

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/README.md
+++ b/reference_files/traefik-portainer-ssl/traefik/README.md
@@ -1,0 +1,8 @@
+# docker-compose.yml
+- In order to properly set your Dashboard password, you will need to encode your credentials.
+  - You can use `basic_auth_pass.py` to perform this operation (recommended) or an online form (not recommended).
+  - Essentially, you will need to write your credentials in `user:password` format and then encode them into Base64.
+  - For example, for a username of "admin" and a password of "mypassword", you need to concatenate them as `admin:mypassword` and then encode this string into Base64 (which would become `YWRtaW46bXlwYXNzd29yZA==`)
+  - The python file is the recommended approach as it does not require any external dependencies.
+- Once you obtain your credentials, you will replace `USER:BASIC_AUTH_PASSWORD` with the encoded credentials.
+  - Using the example credentials `admin:mypassword` above, the line should read `"traefik.http.middlewares.traefik-auth.basicauth.users=YWRtaW46bXlwYXNzd29yZA=="`

--- a/reference_files/traefik-portainer-ssl/traefik/basic_auth_pass.py
+++ b/reference_files/traefik-portainer-ssl/traefik/basic_auth_pass.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import base64
+from getpass import getpass
+
+def encode_auth(username: str, password: str):
+    auth_string = f"{username}:{password}"
+    auth_bytes = auth_string.encode('ascii')
+    b64_bytes = base64.b64encode(auth_bytes)
+    b64_string = b64_bytes.decode('ascii')   
+
+    return b64_string 
+
+def encode_auth_with_input():
+    username = input("Username: ")
+    password = getpass("Password: ")
+
+    return encode_auth(username=username, password=password)
+
+if __name__ == '__main__':
+    print(encode_auth_with_input())


### PR DESCRIPTION
Wrote some brief documentation about how to generate and use the basic auth password and also wrote up a quick python script that users can use to generate one without having to trust their credentials to random internet websites.

Fixes #101 