### PR TITLE
Add missing param for opnsense

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -100,6 +100,7 @@ http:
         - default-headers
         - https-redirectscheme
       tls: {}
+      service: opnsense
    
 
 #endregion


### PR DESCRIPTION
Hi @timothystewart6, first of all, thanks for this amazing work that you are doing. Now I have a valid certificate in my entire homelab :rocket: 

This PR is just to add a missed `service` attribute in the opnsense definition