### PR TITLE
Fixes

### DIFF
--- a/_posts/2020-12-19-rancher-ha-install.md
+++ b/_posts/2020-12-19-rancher-ha-install.md
@@ -55,7 +55,7 @@ user rancher generated (default)
 install `cert-manager`
 
 ```bash
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
 ```
 
 create name-space for `cert-manager`
@@ -86,7 +86,7 @@ the contents of "/etc/rancher/k3s/k3s.yaml" to "~/.kube/config" to resolve the i
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.2.0
+  --version v1.7.1
 ```
 
 check rollout of cert-manager

--- a/_posts/2022-03-26-k3s-etcd-ansible.md
+++ b/_posts/2022-03-26-k3s-etcd-ansible.md
@@ -170,6 +170,11 @@ kubectl delete -f k3s-ansible/example/deployment.yml
 kubectl delete -f k3s-ansible/example/service.yml
 ```
 
+## What's next?
+See here to get the steps for installing [traefik](https://docs.technotim.live/posts/k3s-traefik-rancher/#install-traefik-2)
+
+See here for steps to deploy [rancher](https://docs.technotim.live/posts/rancher-ha-install/#install)
+
 ## Troubleshooting
 
 Be sure to see [this post on](https://github.com/techno-tim/k3s-ansible/discussions/20) how to troubleshoot common problems


### PR DESCRIPTION
updated cert-manager in HA rancher install docs. I think there is a newer release but so far 1.7.1 has been going up just fine with no issues in all my tests.

added a couple ref links in a what's next section for your ansible k3s docs. feel free to make edits if you have a relative path type link instead of a full URL.