### PR TITLE
Update docker-compose.yml

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/docker-compose.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/docker-compose.yml
@@ -18,11 +18,11 @@ services:
       # - CF_API_KEY=YOU_API_KEY
       # be sure to use the correct one depending on if you are using a token or key
     volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /home/username/traefik/data/traefik.yml:/traefik.yml:ro
-      - /home/username/traefik/data/acme.json:/acme.json
-      - /home/username/traefik/data/config.yml:/config.yml:ro
+        - /etc/localtime:/etc/localtime:ro
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+        - /home/username/traefik/data/traefik.yml:/traefik.yml:ro
+        - /home/username/traefik/data/acme.json:/acme.json
+        - /home/username/traefik/data/config.yml:/config.yml:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.traefik.entrypoints=http"


### PR DESCRIPTION
Single indent for Volumes: breaks YML when starting a docker-compose on Debian. Not sure if Debian only issue but the docker instance will continuously restart if Volumes: is not double indented.