### PR TITLE
Fix htpasswd failing on leading special characters

### DIFF
--- a/_posts/2021-04-17-traefik-portainer-ssl.md
+++ b/_posts/2021-04-17-traefik-portainer-ssl.md
@@ -74,7 +74,7 @@ sudo apt install apache2-utils
 ```
 
 ```bash
-echo $(htpasswd -nb <USER> <PASSWORD>) | sed -e s/\\$/\\$\\$/g
+echo $(htpasswd -nb "<USER>" "<PASSWORD>") | sed -e s/\\$/\\$\\$/g
 ```
 
 NOTE: Replace `<USER>` with your username and `<PASSWORD>` with your password to be hashed.


### PR DESCRIPTION
If your password begins with a special character this sometimes fails, I tested and the quotes are not included in the final username and hash