### PR TITLE
Add note pointing to cloud-init images to _posts/2020-11-28-first-11-…

### DIFF
--- a/_posts/2020-11-28-first-11-things-proxmox.md
+++ b/_posts/2020-11-28-first-11-things-proxmox.md
@@ -165,6 +165,8 @@ iface vmbr0 inet static
 
 These are the commands I run after cloning a Linux machine so that it resets all information for the machine it was cloned from.
 
+(Note: If you use cloud-init-aware OS images as described under *Cloud-Init Support* on https://pve.proxmox.com/pve-docs/chapter-qm.html, these steps won't be necessary!)
+
 change hostname
 
 ```bash


### PR DESCRIPTION
…things-proxmox.md

The documentation at https://pve.proxmox.com/pve-docs/chapter-qm.html gives a really nice and easy-to-follow guide on how to set up templates with cloud-init support that do all the steps described here on their own. Debian and Ubuntu offer their official images under

https://cloud.debian.org/images/cloud/

and

https://cloud-images.ubuntu.com/.

I don't know if this guide would be the right place for it, but resizing a vm's hard disk is as easy as

```bash
qm resize 123 scsi0 +10G
```

where `123` is the vm's id, and `+10G` the amount the disk should be increased by (both Debian and Ubuntu's default disk size is 2 gb, so not a lot :sweat_smile: )

Hope this helps!