### PR TITLE
Replacing depreciated sslRedirect

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -187,7 +187,6 @@ http:
     default-headers:
       headers:
         frameDeny: true
-        sslRedirect: true
         browserXssFilter: true
         contentTypeNosniff: true
         forceSTSHeader: true
@@ -201,7 +200,6 @@ http:
     idrac:
       headers:
         frameDeny: true
-        sslRedirect: true
         browserXssFilter: true
         forceSTSHeader: true
         stsIncludeSubdomains: true

--- a/reference_files/traefik-portainer-ssl/traefik/traefik.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/traefik.yml
@@ -4,6 +4,11 @@ api:
 entryPoints:
   http:
     address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: https
+          scheme: https
   https:
     address: ":443"
 serversTransport:


### PR DESCRIPTION
The Traefik logs states that the header is depreciated. 

Read more here:
https://doc.traefik.io/traefik/middlewares/http/headers/#sslredirect

Out of the two suggested methods I have implemented EntryPoint redirection. The other option is RedirectScheme middleware. 

I don't know the pros and cons of them, but as I can't see a case where I would want to use a "true" http-entrypoint, I think this is cleaner.