### PR TITLE
Update traefik.yml

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/traefik.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/traefik.yml
@@ -26,6 +26,7 @@ certificatesResolvers:
       storage: acme.json
       dnsChallenge:
         provider: cloudflare
+        disablePropagationCheck: true
         resolvers:
           - "1.1.1.1:53"
           - "1.0.0.1:53"

--- a/reference_files/traefik-portainer-ssl/traefik/traefik.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/traefik.yml
@@ -26,7 +26,7 @@ certificatesResolvers:
       storage: acme.json
       dnsChallenge:
         provider: cloudflare
-        disablePropagationCheck: true
+        #disablePropagationCheck: true # uncomment this if you have issues pulling certificates through cloudflare, By setting this flag to true disables the need to wait for the propagation of the TXT record to all authoritative name servers.
         resolvers:
           - "1.1.1.1:53"
           - "1.0.0.1:53"


### PR DESCRIPTION
By setting this flag to true disables the need to wait for the propagation of the TXT record to all authoritative name servers.