### PR TITLE
Update 2023-03-25-terraform-cloudflare-github.md

### DIFF
--- a/_posts/2023-03-25-terraform-cloudflare-github.md
+++ b/_posts/2023-03-25-terraform-cloudflare-github.md
@@ -383,7 +383,7 @@ jobs:
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 


### PR DESCRIPTION
I haven't tested this extensively but updating setup-terraform to @v2 stopped the warning "The `set-output` command is deprecated and will be disabled soon". These warnings did not prevent Actions from completing but might eventually. Changing this for my Cloudflare records worked well.