### PR TITLE
Update config.yml

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/config.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/config.yml
@@ -216,7 +216,7 @@ http:
         permanent: true
     redirectregex-pihole:
       redirectRegex:
-        regex: /admin/$
+        regex: "/admin/(.*)"
         replacement: /
 
     default-headers:


### PR DESCRIPTION
Pihole redirectRegex update to handle 404 errors from timeouts from things like authentik, autheilia... etc. This way if you are logged in on a page outside of the url in your proxy config and you hit a timeout, it redirects to the admin page.