### PR TITLE
Update traefik.yml -- add delayBeforeCheck

### DIFF
--- a/reference_files/traefik-portainer-ssl/traefik/traefik.yml
+++ b/reference_files/traefik-portainer-ssl/traefik/traefik.yml
@@ -27,6 +27,7 @@ certificatesResolvers:
       dnsChallenge:
         provider: cloudflare
         #disablePropagationCheck: true # uncomment this if you have issues pulling certificates through cloudflare, By setting this flag to true disables the need to wait for the propagation of the TXT record to all authoritative name servers.
+        #delayBeforeCheck: 60s # uncomment along with disablePropagationCheck if needed to ensure the TXT record is ready before verification is attempted 
         resolvers:
           - "1.1.1.1:53"
           - "1.0.0.1:53"


### PR DESCRIPTION
Adding a commented line for `delayBeforeCheck` to go along with `disablePropagationCheck` to allow the TXT record time to propagate before verification is attempted, otherwise the check can happen too soon and fail.