### PR TITLE
Replacing Winget install id to FireDaemon.OpenSSL

### DIFF
--- a/_posts/2024-12-07-postgresql-high-availability.md
+++ b/_posts/2024-12-07-postgresql-high-availability.md
@@ -144,7 +144,7 @@ Make sure `openssl` is installed
 Windows
 
 ```powershell
-winget install -e --id ShiningLight.OpenSSL
+winget install -e --id FireDaemon.OpenSSL
 ```
 
 macOS


### PR DESCRIPTION
The command to install OpenSSL on Windows OS with Winget is using an ID that no longer exist. I've replaced it with FireDaemon.OpenSSL