### PR TITLE
Replacing ports 8080 with 8008 when doing the curl -k to verify the p…

### DIFF
--- a/_posts/2024-12-07-postgresql-high-availability.md
+++ b/_posts/2024-12-07-postgresql-high-availability.md
@@ -979,9 +979,9 @@ However we don't always know who the leader is so we can't use an IP
 We can test the patroni endpoint to see who is leader
 
 ```bash
-curl -k https://192.168.60.103:8080/primary
-curl -k https://192.168.60.104:8080/primary
-curl -k https://192.168.60.105:8080/primary
+curl -k https://192.168.60.103:8008/primary
+curl -k https://192.168.60.104:8008/primary
+curl -k https://192.168.60.105:8008/primary
 ```
 
 ### Editing your pg_hba after bootstrapping


### PR DESCRIPTION
The patroni endpoint health checks using curl is referencing port 8080, while throughout the documentation the correct port being used is 8008.
Fixing this changing it to the correct port.